### PR TITLE
build(publish): rename package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@modelcontextprotocol/sdk",
-  "version": "1.11.4",
+  "name": "@gleanwork/mcp-sdk",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@modelcontextprotocol/sdk",
-      "version": "1.11.4",
+      "name": "@gleanwork/mcp-sdk",
+      "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,10 @@
 {
-  "name": "@modelcontextprotocol/sdk",
+  "name": "@gleanwork/mcp-sdk",
   "version": "1.12.2",
   "description": "Model Context Protocol implementation for TypeScript",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
-  "homepage": "https://modelcontextprotocol.io",
-  "bugs": "https://github.com/modelcontextprotocol/typescript-sdk/issues",
   "type": "module",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/modelcontextprotocol/typescript-sdk.git"
-  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
`@modelcontextprotocol/sdk` -> `@gleanwork/mcp-sdk`


This is to publish on pkg.pr.new under our own scope.