### PR TITLE
Revert rename + publish to long URLs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,4 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm run lint
-      - run: npx pkg-pr-new publish --compact --bin
+      - run: npx pkg-pr-new publish --bin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@gleanwork/mcp-sdk",
-  "version": "1.12.2",
+  "name": "@modelcontextprotocol/sdk",
+  "version": "1.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@gleanwork/mcp-sdk",
-      "version": "1.12.2",
+      "name": "@modelcontextprotocol/sdk",
+      "version": "1.11.4",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
-  "name": "@gleanwork/mcp-sdk",
+  "name": "@modelcontextprotocol/sdk",
   "version": "1.12.2",
   "description": "Model Context Protocol implementation for TypeScript",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
+  "homepage": "https://modelcontextprotocol.io",
+  "bugs": "https://github.com/modelcontextprotocol/typescript-sdk/issues",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/modelcontextprotocol/typescript-sdk.git"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
- **Revert "build(publish): rename package"**
- **build(publish): publish at longer URLs**


We don't want to publish at pkg.pr.new/@modelcontextprotocol/sdk.  We want to make it clear it's a fork and publish at pkr.pr.new/gleanwork/typescript-sdk/@modelcontextprotcool/sdk.

