### PR TITLE
fix: OpenID configuration lookup

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -276,10 +276,14 @@ export async function discoverOAuthMetadata(
   );
 
   if (metadata === undefined) {
+    let authorizationServerUrlStr = authorizationServerUrl.toString();
+    if (!authorizationServerUrlStr.endsWith("/")) {
+      authorizationServerUrlStr = `${authorizationServerUrlStr}/`;
+    }
     // server 404, in other cases _discoverOAuthMetadata would already have thrown
     metadata = await _discoverOAuthMetadata(
-      authorizationServerUrl,
-      "/.well-known/openid-configuration",
+      authorizationServerUrlStr,
+      ".well-known/openid-configuration",
       opts,
     );
   }


### PR DESCRIPTION
OpenID connect and OAuth Authorization Server Metadata use two different schemas for determining the final well-known URL.

For servers with path components, the ".well-known" segment is inserted between the host and path component for OAuth authorization server metadata, but appended for openid-connect.

e.g. for issuer https://example.com/my-issuer

- https://example.com/.well-known/oauth-authorization-server/my-issuer
- https://example.com/my-issuer/.well-known/openid-configuration

[^1]: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
[^2]: https://datatracker.ietf.org/doc/html/rfc8414#section-3
